### PR TITLE
Add ability to stream all tracks in dashboard

### DIFF
--- a/lib/soundcli.rb
+++ b/lib/soundcli.rb
@@ -33,6 +33,9 @@ EXAMPLES:
    Stream all of your favourite tracks:
        #{$0} me favorites
 
+   Stream all of the tracks on your dashboard:
+       #{$0} me activities
+
 
 
 UNFINISHED STUFF:
@@ -80,6 +83,16 @@ EOF
         :follow => true
       })
       tracks = res[:response].map{|i|i['stream_url']}
+      self.stream tracks
+    elsif ['activities'].include? args[0]
+      res = Helpers::get({
+        :target => 'me/'+args[0],
+        :ssl    => true,
+        :params => params,
+        :follow => true
+      })
+      tracks = res[:response]['collection'].select{|i| i['type'].eql? 'track'}
+      tracks = tracks.map{|i|i['origin']['stream_url']}
       self.stream tracks
     else
       sub = (args.length > 0) ? ('/'+args.join('/')) : ('')


### PR DESCRIPTION
This additional code parses the activities collection for tracks.

This code could be easily be expanded to only select tracks tagged 'exclusive' (as suggested in the command list) or to select playlists instead.

Thanks for this library, it lets me keep up with my SoundCloud dashboard while programming, free of visual distraction!
